### PR TITLE
Add vagrantfile which is rough equivalent to dockerfile, but primarily for bootstrapping dev servers

### DIFF
--- a/vagrantfile
+++ b/vagrantfile
@@ -33,11 +33,11 @@ Vagrant.configure("2") do |config|
       apk del $build_deps
   SCRIPT
 
-  $serve_script = <<-SCRIPT
-    cat << EOD > /usr/bin/serve
+  $serve_script = <<-'SCRIPT'
+    cat << EOD | sed -e  "s#\\\\{#{#g; s#\\\\}#}#g" > /usr/bin/serve
 #!/usr/bin/env bash
-URL="${1:-http://localhost:5000}"
-/usr/bin/tty-server -web_address :5000 --sender_address :6543 -url "$URL"
+URL="$\\{1:-http://localhost:5000\\}"
+/usr/bin/tty-server -web_address :5000 --sender_address :6543 -url "$\\{URL\\}"
 EOD
     chmod a+x /usr/bin/serve
   SCRIPT

--- a/vagrantfile
+++ b/vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   # By connecting to localhost:8080 from the host, we can access the guest's 
   # webserver.
 
-  config.vm.network :forwarded_port, guest: 5000, host: 8080
+  config.vm.network :forwarded_port, guest: 5000, host: 5000 
   config.vm.network :forwarded_port, guest: 22, host: 5522
   config.vm.network :forwarded_port, guest: 6543, host: 6543
   

--- a/vagrantfile
+++ b/vagrantfile
@@ -1,8 +1,7 @@
 Vagrant.configure("2") do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "becorecode/alpinelinux-3.11"
-  config.vm.box_version = "1.0.0"
+  config.vm.box = "ubuntu/focal64"
   
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine.
@@ -17,20 +16,16 @@ Vagrant.configure("2") do |config|
   # Handy if you need to share a clipboard, convey viewport info, etc.
   config.ssh.forward_x11 = true
   
-  config.ssh.shell = "ash"
-  
   $install_script = <<-SCRIPT
     build_deps="go make dep" 
     runtime_deps="dumb-init bash"
 
-    apk update && \
-      apk add -u $build_deps $runtime_deps && \
-      cd /go/src/github.com/elisescu/tty-server && \
-      GOPATH=/go dep ensure && \
-      GOPATH=/go make all && \
-      cp tty-server /usr/bin/ && \
-      rm -r /go && \
-      apk del $build_deps
+    apt-get update && \
+      apt-get install -u $build_deps $runtime_deps && \
+      cd /home/vagrant/go/src/github.com/elisescu/tty-server && \
+      GOPATH=/home/vagrant/go dep ensure && \
+      GOPATH=/home/vagrant/go make all && \
+      ln -s /home/vagrant/go/src/github.com/elisescu/tty-server/tty-server /usr/bin/tty-server
   SCRIPT
 
   $serve_script = <<-'SCRIPT'
@@ -43,7 +38,7 @@ EOD
   SCRIPT
    
   config.vm.provision "file", source: ".", destination: "$HOME/go/src/github.com/elisescu/tty-server"
-  config.vm.provision "shell", inline: 'mv "/home/vagrant/go" "/go"', name: "move_go"
+  # config.vm.provision "shell", inline: 'mv "/home/vagrant/go" "/go"', name: "move_go"
   config.vm.provision "shell", inline: $install_script, name: "install"
   config.vm.provision "shell", inline: $serve_script, name: "serve"
 

--- a/vagrantfile
+++ b/vagrantfile
@@ -1,0 +1,41 @@
+Vagrant.configure("2") do |config|
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "becorecode/alpinelinux-3.11"
+  config.vm.box_version = "1.0.0"
+  
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine.
+  # By connecting to localhost:8080 from the host, we can access the guest's 
+  # webserver.
+
+  config.vm.network :forwarded_port, guest: 5000, host: 8080
+  config.vm.network :forwarded_port, guest: 22, host: 5522
+  config.vm.network :forwarded_port, guest: 6543, host: 6543
+  
+  # Forward x11 via ssh. 
+  # Handy if you need to share a clipboard, convey viewport info, etc.
+  config.ssh.forward_x11 = true
+  
+  config.ssh.shell = "ash"
+  
+  $install_script = <<-SCRIPT
+    build_deps="go make dep" 
+    runtime_deps="dumb-init bash"
+
+    apk update && \
+      apk add -u $build_deps $runtime_deps && \
+      # adduser -D -H -h / -u $user_id tty-server && \
+      cd /go/src/github.com/elisescu/tty-server && \
+      GOPATH=/go dep ensure && \
+      GOPATH=/go make all && \
+      cp tty-server /usr/bin/ && \
+      rm -r /go && \
+      apk del $build_deps
+  SCRIPT
+   
+  config.vm.provision "file", source: ".", destination: "$HOME/go/src/github.com/elisescu/tty-server"
+  config.vm.provision "shell", inline: 'mv "/home/vagrant/go" "/go"'
+  config.vm.provision "shell", inline: $install_script
+
+end

--- a/vagrantfile
+++ b/vagrantfile
@@ -25,7 +25,6 @@ Vagrant.configure("2") do |config|
 
     apk update && \
       apk add -u $build_deps $runtime_deps && \
-      # adduser -D -H -h / -u $user_id tty-server && \
       cd /go/src/github.com/elisescu/tty-server && \
       GOPATH=/go dep ensure && \
       GOPATH=/go make all && \
@@ -33,9 +32,19 @@ Vagrant.configure("2") do |config|
       rm -r /go && \
       apk del $build_deps
   SCRIPT
+
+  $serve_script = <<-SCRIPT
+    cat <<-EOF > /usr/bin/serve
+      #!/usr/bin/env bash
+      URL="${1:-http://localhost:5000}"
+      /usr/bin/tty-server -web_address :5000 --sender_address :6543 -url "$URL"
+    EOF    
+    chmod a+x /usr/bin/serve
+  SCRIPT
    
   config.vm.provision "file", source: ".", destination: "$HOME/go/src/github.com/elisescu/tty-server"
   config.vm.provision "shell", inline: 'mv "/home/vagrant/go" "/go"'
   config.vm.provision "shell", inline: $install_script
+  config.vm.provision "shell", inline: $serve_script
 
 end

--- a/vagrantfile
+++ b/vagrantfile
@@ -34,17 +34,17 @@ Vagrant.configure("2") do |config|
   SCRIPT
 
   $serve_script = <<-SCRIPT
-    cat <<-EOF > /usr/bin/serve
-      #!/usr/bin/env bash
-      URL="${1:-http://localhost:5000}"
-      /usr/bin/tty-server -web_address :5000 --sender_address :6543 -url "$URL"
-    EOF    
+    cat << EOD > /usr/bin/serve
+#!/usr/bin/env bash
+URL="${1:-http://localhost:5000}"
+/usr/bin/tty-server -web_address :5000 --sender_address :6543 -url "$URL"
+EOD
     chmod a+x /usr/bin/serve
   SCRIPT
    
   config.vm.provision "file", source: ".", destination: "$HOME/go/src/github.com/elisescu/tty-server"
-  config.vm.provision "shell", inline: 'mv "/home/vagrant/go" "/go"'
-  config.vm.provision "shell", inline: $install_script
-  config.vm.provision "shell", inline: $serve_script
+  config.vm.provision "shell", inline: 'mv "/home/vagrant/go" "/go"', name: "move_go"
+  config.vm.provision "shell", inline: $install_script, name: "install"
+  config.vm.provision "shell", inline: $serve_script, name: "serve"
 
 end

--- a/vagrantfile
+++ b/vagrantfile
@@ -17,11 +17,11 @@ Vagrant.configure("2") do |config|
   config.ssh.forward_x11 = true
   
   $install_script = <<-SCRIPT
-    build_deps="go make dep" 
+    build_deps="golang make go-dep" 
     runtime_deps="dumb-init bash"
 
     apt-get update && \
-      apt-get install -u $build_deps $runtime_deps && \
+      apt-get install -y $build_deps $runtime_deps && \
       cd /home/vagrant/go/src/github.com/elisescu/tty-server && \
       GOPATH=/home/vagrant/go dep ensure && \
       GOPATH=/home/vagrant/go make all && \

--- a/vagrantfile
+++ b/vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
   
   $install_script = <<-SCRIPT
     build_deps="golang make go-dep" 
-    runtime_deps="dumb-init bash"
+    runtime_deps="dumb-init git"
 
     apt-get update && \
       apt-get install -y $build_deps $runtime_deps && \


### PR DESCRIPTION
YMMVt, I just find docker never works the way I want it to when I'm bootstrapping a project, but vagrant has always been reliable for bootstrapping projects. 

I made this because of #8 , which, for my use-case of providing a dev environment, that just works, it did solve nicely. 
The downside is that you would have 2 different virtualization specs to maintain.