### PR TITLE
Update makefile so make all works in any state (after a full clean)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,9 @@ assets_bundle.go: $(TTY_SERVER_ASSETS)
 %.zip: %
 	zip $@ $^
 
-frontend: frontend/public/index.html
+frontend: cleanfront frontend/public/index.html
 
 frontend/public/index.html:
-	rm -fr frontend/public
 	cd frontend && npm install && npm run build && cd -
 
 cleanfront:

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,12 @@ TTY_SERVER=./tty-server
 TTY_SERVER_ASSETS=$(wildcard frontend/public/*) frontend/public/index.html
 TTY_SERVER_SRC=$(wildcard *.go) assets_bundle.go
 
-.PHONY: all frontend clean cleanfront
+.PHONY: all frontend clean cleanfront rebuild
 
 all: $(TTY_SERVER)
 	@echo "Done"
+
+rebuild: clean all
 
 # Building the server and tty-share
 $(TTY_SERVER): $(TTY_SERVER_SRC)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 TTY_SERVER=./tty-server
 
-TTY_SERVER_ASSETS=$(wildcard frontend/public/*)
+TTY_SERVER_ASSETS=$(wildcard frontend/public/*) frontend/public/index.html
 TTY_SERVER_SRC=$(wildcard *.go) assets_bundle.go
+
+.PHONY: frontend clean cleanfront
 
 all: $(TTY_SERVER)
 	@echo "Done"
@@ -12,17 +14,22 @@ $(TTY_SERVER): $(TTY_SERVER_SRC)
 
 assets_bundle.go: $(TTY_SERVER_ASSETS)
 	go get github.com/go-bindata/go-bindata/...
-	go-bindata --prefix frontend/public/ -o $@ $^
+	go-bindata --prefix frontend/public/ -o $@ frontend/public/*
 
 %.zip: %
 	zip $@ $^
 
-frontend: force
-	cd frontend && npm install && npm run build && cd -
-force:
+frontend: frontend/public/index.html
 
-clean:
-	rm -fr tty-server assets_bundle.go frontend/public
+frontend/public/index.html:
+	rm -fr frontend/public
+	cd frontend && npm install && npm run build && cd -
+
+cleanfront:
+	rm -fr frontend/public
+
+clean: cleanfront
+	rm -fr tty-server assets_bundle.go 
 	@echo "Cleaned"
 
 ## Development helper targets

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TTY_SERVER=./tty-server
 TTY_SERVER_ASSETS=$(wildcard frontend/public/*) frontend/public/index.html
 TTY_SERVER_SRC=$(wildcard *.go) assets_bundle.go
 
-.PHONY: frontend clean cleanfront
+.PHONY: all frontend clean cleanfront
 
 all: $(TTY_SERVER)
 	@echo "Done"


### PR DESCRIPTION
Resolves #12 

* Remove "force" taget 
* mark following as .PHONY:
  * clean, 
   * all
   * frontend & 
    * _(new target)_ cleanfront
* Add target frontend/public/index.html
  * This is a real target, output when frontend is built
   * cleanfront does delete this
 * phony frontend depends on real `frontend/public/index.html`, preceded by phony `cleanfront`, which deletes /invalidates real `frontend/public/index.html`, so clean build is always triggered
* assets_bundle_go depends on real `frontend/public/index.html`, so rebuild only triggers after clean. 

Pretty sure it's better, at least the workflow from clean -> make has less speed bumps.
 
